### PR TITLE
Add repo flag to gh-pages deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "develop": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "deploy": "gatsby build && gh-pages -d public -b main"
+    "deploy": "gatsby build && gh-pages -r git@github.com:mlops-discord/mlops-discord.github.io.git -d public -b main"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
this just makes sure the site you compile gets pushed to the hosting repo instead of this one. It does assume that you have SSH access set up with git